### PR TITLE
Update Styles for Small Toolbar

### DIFF
--- a/styles/darkside.less
+++ b/styles/darkside.less
@@ -3,16 +3,16 @@
 //====================================================
 
 // Default
-@sidebar: #313042;
-@accent: #F18260;
+// @sidebar: #313042;
+// @accent: #F18260;
 
 // Luna
 // @sidebar: #202C46;
 // @accent: #39DFF8;
 
 // Zond
-// @sidebar: #333333;
-// @accent: #F6D49C;
+@sidebar: #333333;
+@accent: #F6D49C;
 
 // Gemini
 // @sidebar: #00203C;
@@ -51,7 +51,7 @@ body {
 .preferences-sidebar,
 .preferences-content,
 .column-DraftList {
-  padding-top: 50px;
+  padding-top: 38px;
   background: @messagelist-bg;
 }
 
@@ -65,6 +65,10 @@ body {
   background: transparent;
   border: none;
   box-shadow: none;
+}
+
+.platform-linux .sheet-toolbar .btn.btn-toolbar.item-compose {
+  order: 101;
 }
 
 .sheet-toolbar .btn.btn-toolbar.item-compose img.content-mask {
@@ -258,6 +262,10 @@ body.is-blurred .list-container .list-item.focused {
 
 .sheet-toolbar .message-toolbar-items {
   margin-right: 11.25px;
+}
+
+.sheet-toolbar .selection-bar {
+  height: 38px;
 }
 
 .mode-toggle.mode-false .content-mask {

--- a/styles/darkside.less
+++ b/styles/darkside.less
@@ -3,16 +3,16 @@
 //====================================================
 
 // Default
-// @sidebar: #313042;
-// @accent: #F18260;
+@sidebar: #313042;
+@accent: #F18260;
 
 // Luna
 // @sidebar: #202C46;
 // @accent: #39DFF8;
 
 // Zond
-@sidebar: #333333;
-@accent: #F6D49C;
+// @sidebar: #333333;
+// @accent: #F6D49C;
 
 // Gemini
 // @sidebar: #00203C;

--- a/styles/darkside.less
+++ b/styles/darkside.less
@@ -281,7 +281,7 @@ body.is-blurred .list-container .list-item.focused {
 [data-reactid=".0.0.1.$=1$1=02Thread=02toolbar.$0"] {
   background-image: none;
   background-color: #e9e9e9;
-  min-height: 50px;
+  min-height: 38px;
 }
 
 //====================================================
@@ -312,7 +312,7 @@ body.is-blurred .list-container .list-item.focused {
 
 .notifications-sticky .notifications-sticky-item {
   background-color: @accent;
-  line-height: 50px;
+  line-height: 38px;
   border: none;
 }
 


### PR DESCRIPTION
In the latest N1 master revision, the toolbar shrank and has smaller icons on all platforms. My changes bring this theme in line with the original N1 themes.

I do hope the N1 team puts more of these magic numbers in variables so a UI change like this doesn't break themes.

EDIT: Solves #3 
