### PR TITLE
Add theme colors and display name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "Darkside",
+  "displayName": "Darkside",
   "theme": "Darkside",
   "version": "1.0.0",
   "description": "A customizable, dark sidebar theme for Nylas N1",

--- a/styles/theme-colors.less
+++ b/styles/theme-colors.less
@@ -1,0 +1,4 @@
+@import "darkside";
+
+@component-active-color: @accent;
+@panel-background-color: @sidebar;


### PR DESCRIPTION
Hey, @jamiewilson! I'm part of the Nylas team, and we're about to land a new visual theme picker that'll allow people to preview and view color palettes for themes. We pull a few major colors from the theme's UI variables to create the palette, but we've also added a way to override them manually with a `theme-colors.less` file for themes (like yours) that don't use UI variables.

Here's how it looks:
<img width="107" alt="screen shot 2016-03-04 at 10 35 35 am" src="https://cloud.githubusercontent.com/assets/8452682/13536462/da82fbfc-e1f4-11e5-9b20-08ddbce09106.png">
