### PR TITLE
Activity Icon Edit

### DIFF
--- a/styles/darkside.less
+++ b/styles/darkside.less
@@ -744,6 +744,11 @@ input[type="email"]:focus,
   padding-right: @sidebar-margin;
 }
 
+// Adds a little breathing room between activity and compose icons
+.toolbar-activity{
+  margin-right: 1em;
+}
+
 // Slightly darker toolbar for Prefs, Single Panel Messages, and Popout
 .toolbar-Preferences,
 .layout-mode-list .toolbar-MessageList,


### PR DESCRIPTION
Added `margin-right` to the activity icon to give the notifications a little breathing room next to the compose icon/button... at least on my MBPro Retina the icons felt snug and maybe had 1 or 2 pixels of space. 
